### PR TITLE
Fix for XSS vulnerability in the 'url' parameter in ombott/error_render.py when an error is rendered

### DIFF
--- a/ombott/error_render.py
+++ b/ombott/error_render.py
@@ -1,10 +1,12 @@
 from pathlib import Path
+import html as sanitize_html
 
 html = Path(__file__).parent / 'error.html'
 
 _html_lns = []
 
 def render(err_resp, url, debug):
+    clean_url = sanitize_html.escape(url)
     ex = traceback = '-] Forbidden [-'
     if debug:
         traceback = err_resp.traceback
@@ -17,7 +19,7 @@ def render(err_resp, url, debug):
         e = err_resp,
         exception = ex,
         traceback = traceback,
-        url = repr(url)
+        url = repr(clean_url)
     )
 
     if not _html_lns:


### PR DESCRIPTION
There is a XSS Reflected vulnerability in 'url' parameter when an error is rendered.

<img width="764" alt="image" src="https://github.com/valq7711/ombott/assets/40671439/0d246f95-0c6d-49c9-9ecf-bff1a545b855">

<img width="1112" alt="image" src="https://github.com/valq7711/ombott/assets/40671439/fa4a2ed8-2cdf-4722-a440-c7a0c250b733">



 sanitizing the 'url' parameter fix this issue:
 
 
<img width="1333" alt="image" src="https://github.com/valq7711/ombott/assets/40671439/e55a2fab-1746-4e4c-aa74-444252e59934">
