### PR TITLE
Patch fullpath function implementation to correctly build paths 

### DIFF
--- a/ombott/request_pkg/props_mixin.py
+++ b/ombott/request_pkg/props_mixin.py
@@ -118,7 +118,7 @@ class PropsMixin:
     def fullpath(self):
         """ Request path including :attr:`script_name` (if present). """
         appname = self._env_get(self.config.app_name_header, '/')
-        return urljoin(self.script_name, self.path[len(appname):].lstrip('/'))
+        return urljoin(self.script_name, self.path[len(appname)+1:].lstrip('/'))
 
     @property
     def query_string(self):


### PR DESCRIPTION
In `request_pkg/props_mixin.py` there is an issue with how the `fullpath` is constructed:
```
    def fullpath(self):
        """ Request path including :attr:`script_name` (if present). """
        appname = self._env_get(self.config.app_name_header, '/')
        return urljoin(self.script_name, self.path[len(appname):].lstrip('/'))
```

For example data:

```
path = '/app1/config/test'
appname = 'app1'
```

The problem is that: `path[len(appname):].lstrip('/')` evaluates to `1/config/test`. 😔

Clearly there is not enough characters removed - there needs to be one more removed. This PR addresses this.
